### PR TITLE
Make keebs and kits mandatory arguments

### DIFF
--- a/src/keycov/args.py
+++ b/src/keycov/args.py
@@ -53,7 +53,6 @@ args:[dict] = [
         'type': str,
         'sanitiser': dir_str,
         'metavar': 'kit-dir',
-        'default': rel_path('kits')
     },
     {
         'dest': 'target_dir',
@@ -63,7 +62,6 @@ args:[dict] = [
         'type': str,
         'sanitiser': dir_str,
         'metavar': 'keeb-dir',
-        'default': rel_path('keebs')
     },
     {
         'dest': 'output_format',
@@ -164,7 +162,7 @@ def parse_args(iargs: tuple) -> Namespace:
     # Sanitise and obtain parsed arguments
     pargs: dict = ap.parse_args(iargs[1:]).__dict__
 
-    dargs = { a['dest']: a['default'] for a in args if 'dest' in a }
+    dargs = { a['dest']: a['default'] for a in args if 'dest' in a and 'default' in a }
     rargs: dict = dict_union_ignore_none(dargs, pargs)
     #  rargs = dict(map(lambda p: (p[0], arg_dict[p[0]]['type'](p[1])), rargs.items()))
     checkResult:str = check_args(rargs)

--- a/src/keycov/util.py
+++ b/src/keycov/util.py
@@ -1,5 +1,5 @@
 from functools import reduce
-from typing import Tuple
+from typing import Callable, Tuple
 
 default_terminal_dims:Tuple[int, int] = (80, 24)
 special_properties:dict = {
@@ -69,3 +69,9 @@ def key_pretty_name(key:dict) -> str:
             key_props += flag
 
     return '-'.join([name, dimensions] + ([key_props] if key_props else []))
+
+def compose(f:Callable, g:Callable) -> Callable:
+    return lambda x: f(g(x))
+
+def notf(c:bool) -> bool:
+    return not c


### PR DESCRIPTION
### What's changed?

Previously, keyboards and kits were optional arguments with default values.
They are now mandatory, allowing the binary to be easily used from anywhere on the system without needing to reference any data-files.
