### PR TITLE
Approximate coverage analysis option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,13 @@ If you’d like to contribute, please abide by the [code of conduct.][code-of-co
 
 This [code][github] was written by Ed Jones (Discord `@kcza#4691`).
 
-Please don’t be surprised if KeyCov takes a while to perform its analyses, finding a minimum-size set of kits which cover a keyboard is believed to be a computationally-hard problem (the time to solve it scales very poorly with the size of the input).
-More specifically, it reduces to [set cover,][set-cover] a standard problem in theoretical computer science for which:
+Please don’t be surprised if KeyCov takes a while to perform its analyses, with many input layouts, there is an exponentially-large number of states which must be checked in order to return accurate results.
+
+There is an option to speed up the analysis (`-q`/`--quick-coverage-analysis`) by not considering the kits chosen in reaching a certain coverage-point, but some caution is advised.
+When used, the result for whether there _exists_ a covering set is still guaranteed to be correct, but the _number_ of covering sets becomes a lower-bound, and the size of the smallest covering set becomes an upper-bound as some possibilities can be disregarded.
+
+This faster version can still take one time, but at this point the problem of finding a more efficient algorithm becomes a fundamental one.
+The problem now considered is exactly [set cover,][set-cover] a standard problem in theoretical computer science for which:
 
 1. We do not know of an algorithm which runs in less-than exponential time and,
 2. We do not know whether one _can_ or _cannot_ exist on our classical hardware.

--- a/src/keycov/analyses.py
+++ b/src/keycov/analyses.py
@@ -263,7 +263,7 @@ def get_units(key:dict) -> float:
     return max(considered_dims)
 
 def compute_covering_set(pargs:Namespace, _:dict, keeb:Tuple[str, List[dict]], kits:List[Tuple[str, List[dict]]]) -> List[Tuple[str, List[dict]]]:
-    covering_sets:List[Tuple[str, List[dict]]] = get_covering_sets(keeb, kits)
+    covering_sets:List[Tuple[str, List[dict]]] = get_covering_sets(pargs.approximate_coverage_analysis, keeb, kits)
     if not covering_sets:
         return FailedAnalysisResult(covering_sets)
     return covering_sets

--- a/src/keycov/args.py
+++ b/src/keycov/args.py
@@ -133,6 +133,15 @@ args:[dict] = [
         'help': 'Set the colour theme for the text-output tables',
         'type': str,
         'default': ''
+    },
+    {
+        'dest': 'approximate_coverage_analysis',
+        'short': '-q',
+        'long': '--quick-coverage-analysis',
+        'action': 'store_true',
+        'help': 'Speed up coverage analysis by making some states indistinguishable. Does not affect checking for the existence of a covering set but other analysis is weakened to only bounds. See the README.',
+        'type': bool,
+        'default': False,
     }
 ]
 arg_dict:dict = { a['dest']: a for a in args if 'dest' in a }

--- a/src/keycov/coverage_analyser.py
+++ b/src/keycov/coverage_analyser.py
@@ -5,7 +5,7 @@ from math import ceil, sqrt, gcd as hcf
 from re import match
 from typing import List, Set, Tuple
 
-def get_covering_sets(to_cover:Tuple[str, List[dict]], sets:Set[Tuple[str, List[dict]]]) -> List[Tuple[str, List[dict]]]:
+def get_covering_sets(approximate_analysis:bool, to_cover:Tuple[str, List[dict]], sets:Set[Tuple[str, List[dict]]]) -> List[Tuple[str, List[dict]]]:
     # Generate a unique prime for each unique key
     prime:iter = primes()
     seen_keys:dict = {}
@@ -18,7 +18,9 @@ def get_covering_sets(to_cover:Tuple[str, List[dict]], sets:Set[Tuple[str, List[
     primed_to_cover = (to_cover[0], reduce(mult, map(lambda k: seen_keys[k['serialised']], to_cover[1]), 1))
     primed_sets = list(map(lambda s: (s[0], next(prime), reduce(mult, map(lambda k: seen_keys[k['serialised']], s[1]), 1)), sets))
 
-    # Set of tuples containing the remainder and set of currently chosen keysets (as a number)
+    # Set of:
+    #   if approximate_coverage_analysis: tuples containing the remainder and set of currently chosen keysets (as a number)
+    #   else:                             remainders and set of currently chosen keysets (as a number)
     seen:Set[Tuple[int, int]] = set()
     ##
     # @brief Perform a depth-first search on the set to cover,k
@@ -31,7 +33,7 @@ def get_covering_sets(to_cover:Tuple[str, List[dict]], sets:Set[Tuple[str, List[
     #
     # @return
     def primes_dfs(r:int, cp:int, csp:int, csns:[str], psets:List[Tuple[str, int, int]]) -> [[str]]:
-        seen.add((r, cp))
+        seen.add((r, cp) if not approximate_analysis else csp)
         if r == 1:
             return [csns]
         elif psets == []:
@@ -43,7 +45,9 @@ def get_covering_sets(to_cover:Tuple[str, List[dict]], sets:Set[Tuple[str, List[
             cp2:int = cp * p
             csp2:int = csp * kn
             # Explore beneficial unexplored children
-            if r != r2 and (r2, cp2) not in seen:
+            if r != r2 \
+                    and (not approximate_analysis or csp2 not in seen) \
+                    and (approximate_analysis or (r2, cp2) not in seen):
                 psets2:List[Tuple[str, int, int]] = copy(psets)
                 psets2.remove((n,p,kn))
                 child_covering_sets.extend(primes_dfs(r2, cp2, csp2, csns + [n], psets2))


### PR DESCRIPTION
### What's changed?

Previously, the complete coverage-analysis was the only option.
Now, users can request an approximate one which is still correct for the existence of a covering set, but which weakens guarantees for the results of dependent analyses.
